### PR TITLE
Add preeclampsia screening documentation

### DIFF
--- a/src/content/docs/san-khoa/sang-loc-chan-doan/01_sang-loc-chan-doan-truoc-sinh.md
+++ b/src/content/docs/san-khoa/sang-loc-chan-doan/01_sang-loc-chan-doan-truoc-sinh.md
@@ -11,9 +11,21 @@ description: Xu thế và ứng dụng chẩn đoán trước sinh.
 
 - **Phát hiện sớm các bất thường nhiễm sắc thể** (Down, Edwards, Patau...).
 - **Xác định các dị tật bẩm sinh** (dị tật ống thần kinh, tim bẩm sinh...).
+- **Tầm soát các biến chứng thai kỳ quan trọng** (tiền sản giật).
 - **Hỗ trợ tư vấn di truyền**, giúp đưa ra quyết định quản lý thai kỳ phù hợp.
 
 ## Các phương pháp sàng lọc trước sinh
+
+### Sàng lọc tiền sản giật
+
+Đây là một phần quan trọng của sàng lọc trước sinh, nhằm phát hiện sớm nguy cơ mắc bệnh lý tăng huyết áp nguy hiểm nhất trong thai kỳ.
+
+- **Quý 1 (11 tuần – 13 tuần 6 ngày):** Sử dụng thuật toán FMF kết hợp yếu tố mẹ, huyết áp (MAP), siêu âm (UtPI) và xét nghiệm máu (PlGF). Mục đích chính là dự phòng bằng Aspirin liều thấp.
+- **Quý 2 & 3:** Sử dụng tỷ số **sFlt-1/PlGF** để tiên đoán nguy cơ xuất hiện tiền sản giật trong ngắn hạn (1-4 tuần).
+
+:::tip[Chi tiết]
+Xem chi tiết tại bài viết: [Tầm soát và dự phòng tiền sản giật](/san-khoa/tang-huyet-ap/04_tam-soat-va-du-phong).
+:::
 
 ### Double test
 
@@ -24,7 +36,7 @@ Xét nghiệm sàng lọc trước sinh không xâm lấn, thực hiện trong t
 **Hạn chế:**
 
 - Không sàng lọc dị tật ống thần kinh.
-- Độ chính xác thấp hơn NIPT: Độ nhạy 85-90% với hội chứng Down, 75-85% với Trisomy 18, 65-75% với Trisomy 13. Dương tính giả khoảng 5%, âm tính giả 10-15%.
+- Độ chính xác thấp hơn NIPT: Độ nhạy 85-90% với hội chứng Down, 75-85% với Trisomy 18, 65-75% with Trisomy 13. Dương tính giả khoảng 5%, âm tính giả 10-15%.
 - Kết quả bị ảnh hưởng bởi tuổi mẹ, cân nặng, tình trạng thai đôi, bệnh lý của mẹ, hút thuốc.
 
 Double test chính xác hơn Triple test, đặc biệt khi kết hợp với siêu âm NT.

--- a/src/content/docs/san-khoa/tang-huyet-ap/04_tam-soat-va-du-phong.md
+++ b/src/content/docs/san-khoa/tang-huyet-ap/04_tam-soat-va-du-phong.md
@@ -1,34 +1,62 @@
 ---
 title: Tầm soát và dự phòng tiền sản giật
-description: Tầm soát tiền sản giật quý 1.
+description: Tầm soát và dự phòng tiền sản giật trong thai kỳ (quý 1, quý 2, ý nghĩa).
 ---
 
-Việc tầm soát và dự phòng tiền sản giật là quan trọng để đảm bảo an toàn cho mẹ và thai nhi, vì tiền sản giật thường khởi phát âm thầm, nhưng có thể diễn tiến nhanh và gây hậu quả nghiêm trọng nếu không phát hiện sớm. Tầm soát tiền sản giật là quá trình xác định sớm nguy cơ từ tam cá nguyệt đầu tiên (trước 13 tuần) để có biện pháp can thiệp kịp thời.
+Việc tầm soát và dự phòng tiền sản giật là quan trọng để đảm bảo an toàn cho mẹ và thai nhi, vì tiền sản giật thường khởi phát âm thầm, nhưng có thể diễn tiến nhanh và gây hậu quả nghiêm trọng nếu không phát hiện sớm.
 
-**Tính nguy cơ** theo [thuật toán của FMF (The Fetal Medicine Foundation)](https://fetalmedicine.org/research/assess/preeclampsia/first-trimester). Nguy cơ cao khi > 1/100.
+## Ý nghĩa của tầm soát
 
-## Đánh giá nguy cơ
+- **Phát hiện sớm nhóm nguy cơ cao:** Cho phép can thiệp kịp thời bằng Aspirin liều thấp trước 16 tuần, giúp giảm đến 70-80% nguy cơ tiền sản giật sớm (trước 34 tuần).
+- **Phân loại quản lý:** Giúp bác sĩ có kế hoạch theo dõi sát sao hơn cho những sản phụ có nguy cơ.
+- **Dự báo ngắn hạn:** Ở giai đoạn muộn (quý 2, quý 3), tầm soát giúp dự báo khả năng xuất hiện tiền sản giật trong vòng 1-4 tuần tới, từ đó có kế hoạch nhập viện hoặc chấm dứt thai kỳ an toàn.
+- **Giảm biến chứng:** Giảm tỷ lệ tử vong và bệnh tật cho cả mẹ (sản giật, HELLP, suy thận) và thai (thai chậm tăng trưởng, sinh non).
+
+## Tầm soát quý 1 (11 tuần – 13 tuần 6 ngày)
+
+Đây là thời điểm **vàng** để tầm soát nhằm mục đích dự phòng.
+
+**Phương pháp:** Tầm soát kết hợp theo [thuật toán của FMF (The Fetal Medicine Foundation)](https://fetalmedicine.org/research/assess/preeclampsia/first-trimester). Nguy cơ cao khi **> 1/100**.
+
+Các yếu tố đánh giá bao gồm:
+
+1.  **Yếu tố mẹ:** Tuổi, chiều cao, cân nặng, chủng tộc, tiền căn bản thân và gia đình, phương pháp thụ thai (IVF).
+2.  **Huyết áp động mạch trung bình (MAP):** Đo ở cả hai tay theo quy trình chuẩn.
+3.  **Chỉ số xung động mạch tử cung (UtPI):** Thực hiện qua siêu âm.
+4.  **Dấu ấn sinh học:** Nồng độ **PlGF** (Placental Growth Factor) trong máu mẹ.
+
+### Đánh giá nguy cơ theo lâm sàng
 
 _Bảng "Đánh giá lâm sàng nguy cơ tiền sản giật"_.
 
-| Đánh giá lâm sàng nguy cơ tiền sản giật | Yếu tố nguy cơ                                                                                                                                                                                                                                                               | Khuyến cáo                                                                  |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **Cao**                                 | - Tiền sử tiền sản giật (đặc biệt kèm kết cục xấu)<br>- Đa thai<br>- Tăng huyết áp mạn tính<br>- Đái tháo đường type 1/type 2<br>- Bệnh thận<br>- Bệnh lý tự miễn (Lupus ban đỏ, hội chứng kháng Phospholipid)                                                               | **Khuyến cáo dùng aspirin liều thấp** khi có ≥ 1 yếu tố nguy cơ cao.        |
-| **Trung bình**                          | - Con so<br>- Béo phì (BMI > 30)<br>- Tiền sử gia đình tiền sản giật (mẹ/chị em gái)<br>- Kinh tế-xã hội thấp/người Mỹ gốc Phi<br>- Sinh con nhẹ cân, thai tăng trưởng hạn chế trong tử cung<br>- Kết cục xấu ở thai kỳ trước<br>- Khoảng cách giữa 2 lần mang thai > 10 năm | **Khuyến cáo dùng aspirin liều thấp** khi có ≥ 2 yếu tố nguy cơ trung bình. |
-| **Thấp**                                | - Thai kỳ trước đủ tháng không biến chứng                                                                                                                                                                                                                                    | **Không khuyến cáo dùng aspirin liều thấp.**                                |
+| Nguy cơ        | Yếu tố nguy cơ                                                                                                                                                                                                    | Khuyến cáo                               |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------- |
+| **Cao**        | - Tiền sử tiền sản giật (đặc biệt kèm kết cục xấu)<br>- Đa thai<br>- Tăng huyết áp mạn tính<br>- Đái tháo đường type 1/type 2<br>- Bệnh thận<br>- Bệnh lý tự miễn (Lupus, hội chứng kháng Phospholipid)           | **Aspirin liều thấp** khi có ≥ 1 yếu tố. |
+| **Trung bình** | - Con so<br>- Béo phì (BMI > 30)<br>- Tiền sử gia đình (mẹ/chị em gái bị TSG)<br>- Kinh tế-xã hội thấp<br>- Sinh con nhẹ cân/SGA thai kỳ trước<br>- Kết cục xấu thai kỳ trước<br>- Khoảng cách mang thai > 10 năm | **Aspirin liều thấp** khi có ≥ 2 yếu tố. |
+| **Thấp**       | - Thai kỳ trước đủ tháng không biến chứng                                                                                                                                                                         | Không khuyến cáo Aspirin.                |
+
+## Tầm soát quý 2 và quý 3 (Từ 20 tuần)
+
+Ở giai đoạn này, mục tiêu chính là **tiên đoán và chẩn đoán phân biệt** hơn là dự phòng.
+
+**Dấu ấn sử dụng:** Tỷ số **sFlt-1/PlGF** (Yếu tố kháng tạo mạch/Yếu tố tân tạo mạch).
+
+| Tỷ số sFlt-1/PlGF                                             | Ý nghĩa và xử trí                                                                                                                              |
+| :------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| **< 38**                                                      | **Nguy cơ thấp:** Loại trừ khả năng xuất hiện tiền sản giật trong vòng **1 tuần** tới (giá trị tiên đoán âm > 99%). Có thể theo dõi ngoại trú. |
+| **38 - 85** (thai < 34 tuần)<br>**38 - 110** (thai ≥ 34 tuần) | **Nguy cơ trung bình:** Theo dõi sát lâm sàng và xét nghiệm. Có khả năng xuất hiện tiền sản giật trong vòng 4 tuần.                            |
+| **> 85** (thai < 34 tuần)<br>**> 110** (thai ≥ 34 tuần)       | **Nguy cơ cao:** Khả năng cao đang có tiền sản giật hoặc sẽ xuất hiện rất sớm. Cần nhập viện theo dõi chặt chẽ.                                |
 
 ## Dự phòng
 
-**Aspirin liều thấp** (WHO khuyến cáo):
+**Aspirin liều thấp:**
 
-- 81-162 mg/ngày (1-2 viên 81 mg), uống buổi tối sau ăn 15-30 phút.
-- Khởi trị khi nguy cơ FMF > 1/100.
-- Tiếp tục đến tuần 36.
+- **Liều lượng:** 81 - 150 mg/ngày (thường dùng 100mg hoặc 150mg tùy phác đồ).
+- **Thời điểm uống:** Buổi tối trước khi đi ngủ (giúp hạ áp hiệu quả hơn).
+- **Thời gian bắt đầu:** Tốt nhất là tuần **12 - 16**, muộn nhất là trước 28 tuần. Tuy nhiên, hiệu quả nhất là bắt đầu **trước 16 tuần**.
+- **Thời gian dừng:** Tuần 36 của thai kỳ.
 
-**Theo ACOG:**
-
-- Khởi aspirin từ tuần 12-16, tối đa không muộn hơn 28 tuần.
-- Dừng vào tuần 36.
+**Bổ sung Canxi:** 1.5 - 2g/ngày cho những sản phụ có chế độ ăn thiếu Canxi (giúp giảm nguy cơ tiền sản giật).
 
 ![Lưu đồ tầm soát tiền sản giật 3 tháng đầu - Bệnh viện Từ Dũ](./_images/luu-do-tam-soat-tien-san-giat-3-thang-dau.png)
 _Hình ảnh "Lưu đồ tầm soát tiền sản giật 3 tháng đầu - Bệnh viện Từ Dũ"_.
@@ -37,3 +65,4 @@ _Hình ảnh "Lưu đồ tầm soát tiền sản giật 3 tháng đầu - Bện
 
 - Trường ĐH Y Dược TP. HCM (2020) - _Team-based learning_
 - Bệnh viện Từ Dũ (2022) - _Phác đồ điều trị Sản Phụ khoa_
+- Fetal Medicine Foundation (FMF)


### PR DESCRIPTION
This PR adds comprehensive information about preeclampsia screening in the first and second trimesters. It covers the clinical significance, the FMF algorithm for the 1st trimester, and the sFlt-1/PlGF ratio for the 2nd/3rd trimesters. It also updates the prenatal screening overview to include preeclampsia.

---
*PR created automatically by Jules for task [10095377394205945532](https://jules.google.com/task/10095377394205945532) started by @torn4dom4n*