### PR TITLE
Add Google AdSense integration and ads.txt

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -30,6 +30,16 @@ export default defineConfig({
     starlight({
       routeMiddleware: "./src/routeData.ts",
       title: "18 Months",
+      head: [
+        {
+          tag: "script",
+          attrs: {
+            async: true,
+            src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2837724975096238",
+            crossorigin: "anonymous",
+          },
+        },
+      ],
       logo: {
         src: "/src/assets/logo.png",
         alt: "18 Months Logo",

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2837724975096238, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This pull request implements Google AdSense integration for the 18 Months documentation site. 

Key changes:
1. Created `public/ads.txt` with the specified publisher verification entry (`google.com, pub-2837724975096238, DIRECT, f08c47fec0942fa0`).
2. Configured Starlight's global HTML `<head>` tag in `astro.config.ts` to include the Google AdSense loader script pointing to publisher ID `pub-2837724975096238` with proper `async` and `crossorigin` attributes.
3. Verified the build successfully outputs `ads.txt` at the root directory (`dist/ads.txt`) and correctly injects the script into all compiled HTML files.
4. Performed frontend verification using Playwright to ensure the home page is unaffected visually and has the script injected correctly.

---
*PR created automatically by Jules for task [18252980633147879607](https://jules.google.com/task/18252980633147879607) started by @torn4dom4n*